### PR TITLE
Add SEO README, fix package installation, and add sitemap generator

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,13 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npx lychee --no-progress docs
+      - run: node scripts/build-sitemap.mjs
+      - name: Commit sitemap
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          git add docs/sitemap.xml
+          git commit -m "chore: update sitemap" || echo "no changes"
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Very Little Text
+
+Very Little Text is an **AI-driven microfiction site generator** built with Node.js. Feed it a JSON file of stories and it outputs a static website packed with structured data for search engines.
+
+## Features
+- Generates SEO-friendly pages with JSON-LD and Open Graph tags
+- Designed for publishing bite-size, AI-crafted stories
+- Minimal Node.js build script with no runtime dependencies
+
+## Getting Started
+### Prerequisites
+- [Node.js](https://nodejs.org/) 18 or later
+
+### Build the site
+```bash
+npm run build
+```
+This creates the `docs/` directory with the homepage, individual episodes, RSS feed, and sitemap.
+
+### Run tests
+```bash
+npm test
+```
+The tests verify that generated pages exist and include structured data.
+
+## Project Structure
+- `data/stories.json` – source stories and site metadata
+- `generate.mjs` – converts `stories.json` into static HTML
+- `docs/` – output folder ready to deploy to any static host
+
+## SEO for AI Microfiction
+Each episode page embeds JSON-LD schema and descriptive metadata so search engines and AI tools can easily index the stories. The concise microfiction format makes content digestible for humans and machines alike.
+
+## License
+Distributed under the MIT License. See `LICENSE` for more information.

--- a/data/stories.json
+++ b/data/stories.json
@@ -1,7 +1,7 @@
 {
   "site": {
     "name": "Very Little Text",
-    "baseUrl": "https://example.com",
+    "baseUrl": "https://verylittletext.com",
     "tagline": "AI-crafted micro-text that blooms into actions."
   },
   "stories": [

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://example.com/sitemap.xml
+Sitemap: https://verylittletext.com/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://example.com/</loc><lastmod>2024-01-07</lastmod></url>
-  <url><loc>https://example.com/episodes/2024-01-07/</loc><lastmod>2024-01-07</lastmod></url>
-  <url><loc>https://example.com/episodes/2024-01-06/</loc><lastmod>2024-01-06</lastmod></url>
-  <url><loc>https://example.com/episodes/2024-01-05/</loc><lastmod>2024-01-05</lastmod></url>
-  <url><loc>https://example.com/episodes/2024-01-04/</loc><lastmod>2024-01-04</lastmod></url>
-  <url><loc>https://example.com/episodes/2024-01-03/</loc><lastmod>2024-01-03</lastmod></url>
-  <url><loc>https://example.com/episodes/2024-01-02/</loc><lastmod>2024-01-02</lastmod></url>
-  <url><loc>https://example.com/episodes/2024-01-01/</loc><lastmod>2024-01-01</lastmod></url>
+  <!-- Starter sitemap; build script will replace with full episode list -->
+  <url>
+    <loc>https://verylittletext.com/</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://verylittletext.com/episodes/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "little-words",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "little-words",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "scripts": {
     "build": "node generate.mjs",
     "test": "node test.mjs",
-    "check": "npx lychee --no-progress docs"
-  },
-  "devDependencies": {
-    "lychee": "^0.13.0"
+    "build:sitemap": "node scripts/build-sitemap.mjs"
   }
 }

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://example.com/sitemap.xml
+Sitemap: https://verylittletext.com/sitemap.xml

--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -1,0 +1,81 @@
+// scripts/build-sitemap.mjs
+// Build sitemap.xml from data/stories.json → docs/sitemap.xml
+// Deterministic, no network calls.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, "..");
+
+const dataPath   = path.join(repoRoot, "data", "stories.json");
+const outDir     = path.join(repoRoot, "docs");
+const outPath    = path.join(outDir, "sitemap.xml");
+
+// ---- load site + stories
+if (!fs.existsSync(dataPath)) {
+  throw new Error(`Missing ${dataPath}`);
+}
+const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
+const baseUrl = (data.site?.baseUrl || "").replace(/\/+$/,"");
+if (!baseUrl) throw new Error("data.site.baseUrl is required (e.g., https://verylittletext.com)");
+
+let stories = Array.isArray(data.stories) ? data.stories.slice() : [];
+// normalize + sort newest→oldest
+stories = stories.map(s => ({
+  ...s,
+  date: s.date || new Date().toISOString().slice(0,10), // default today
+  slug: s.slug || slugify(s.title || "episode")
+})).sort((a,b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+
+// ---- url helpers
+const urls = new Set();
+const add = (loc, changefreq="daily", priority="0.8", lastmodIso=null) => {
+  urls.add(xmlUrl({ loc, changefreq, priority, lastmodIso }));
+};
+const todayIso = new Date().toISOString();
+
+// core pages
+add(`${baseUrl}/`, "daily", "0.9", todayIso);
+add(`${baseUrl}/episodes/`, "weekly", "0.6", stories[0]?.date ? `${stories[0].date}T00:00:00Z` : todayIso);
+
+// episodes
+for (const s of stories) {
+  const lastmod = `${s.date}T00:00:00Z`;
+  add(`${baseUrl}/episodes/${s.date}/`, "weekly", "0.7", lastmod);
+}
+
+// ---- write xml
+const xml = [
+  `<?xml version="1.0" encoding="UTF-8"?>`,
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`,
+  ...urls,
+  `</urlset>\n`
+].join("\n");
+
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(outPath, xml, "utf8");
+console.log(`wrote ${path.relative(repoRoot, outPath)} (${urls.size} urls)`);
+
+// ---- helpers
+function xmlUrl({ loc, changefreq, priority, lastmodIso }) {
+  const parts = [
+    `  <url>`,
+    `    <loc>${escapeXml(loc)}</loc>`,
+    lastmodIso ? `    <lastmod>${escapeXml(lastmodIso)}</lastmod>` : null,
+    changefreq ? `    <changefreq>${changefreq}</changefreq>` : null,
+    priority ? `    <priority>${priority}</priority>` : null,
+    `  </url>`
+  ].filter(Boolean);
+  return parts.join("\n");
+}
+function escapeXml(s) {
+  return String(s).replace(/[<>&'"]/g, ch => (
+    {"<":"&lt;","&":"&amp;",">":"&gt;","'":"&apos;","\"":"&quot;"}[ch]
+  ));
+}
+function slugify(s) {
+  return String(s).toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/(^-|-$)/g,"");
+}


### PR DESCRIPTION
## Summary
- Add sitemap builder script and wire it into CI
- Point robots.txt at the sitemap and set site base URL
- Seed repo with starter sitemap for crawlers

## Testing
- `npm test`
- `npm run build:sitemap`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_689e4dc79aec83299d24e5fb3e5a3da3