### PR TITLE
Refine flood mode styling and fix toggle duplication

### DIFF
--- a/docs/episodes/2025-08-14/index.html
+++ b/docs/episodes/2025-08-14/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -128,16 +125,6 @@
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-15/index.html
+++ b/docs/episodes/2025-08-15/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -121,16 +118,6 @@ Evening arrives and still the words continue, reflecting on shadows, on silence,
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-16/index.html
+++ b/docs/episodes/2025-08-16/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-17/index.html
+++ b/docs/episodes/2025-08-17/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-18/index.html
+++ b/docs/episodes/2025-08-18/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-19/index.html
+++ b/docs/episodes/2025-08-19/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-20/index.html
+++ b/docs/episodes/2025-08-20/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-21/index.html
+++ b/docs/episodes/2025-08-21/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-22/index.html
+++ b/docs/episodes/2025-08-22/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-23/index.html
+++ b/docs/episodes/2025-08-23/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-24/index.html
+++ b/docs/episodes/2025-08-24/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-25/index.html
+++ b/docs/episodes/2025-08-25/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-26/index.html
+++ b/docs/episodes/2025-08-26/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-27/index.html
+++ b/docs/episodes/2025-08-27/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-28/index.html
+++ b/docs/episodes/2025-08-28/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-29/index.html
+++ b/docs/episodes/2025-08-29/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-30/index.html
+++ b/docs/episodes/2025-08-30/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-08-31/index.html
+++ b/docs/episodes/2025-08-31/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-01/index.html
+++ b/docs/episodes/2025-09-01/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-02/index.html
+++ b/docs/episodes/2025-09-02/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-03/index.html
+++ b/docs/episodes/2025-09-03/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-04/index.html
+++ b/docs/episodes/2025-09-04/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-05/index.html
+++ b/docs/episodes/2025-09-05/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-06/index.html
+++ b/docs/episodes/2025-09-06/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-07/index.html
+++ b/docs/episodes/2025-09-07/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-08/index.html
+++ b/docs/episodes/2025-09-08/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-09/index.html
+++ b/docs/episodes/2025-09-09/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-10/index.html
+++ b/docs/episodes/2025-09-10/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-11/index.html
+++ b/docs/episodes/2025-09-11/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-12/index.html
+++ b/docs/episodes/2025-09-12/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-13/index.html
+++ b/docs/episodes/2025-09-13/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-14/index.html
+++ b/docs/episodes/2025-09-14/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-15/index.html
+++ b/docs/episodes/2025-09-15/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-16/index.html
+++ b/docs/episodes/2025-09-16/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-17/index.html
+++ b/docs/episodes/2025-09-17/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-18/index.html
+++ b/docs/episodes/2025-09-18/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-19/index.html
+++ b/docs/episodes/2025-09-19/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-20/index.html
+++ b/docs/episodes/2025-09-20/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-21/index.html
+++ b/docs/episodes/2025-09-21/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-22/index.html
+++ b/docs/episodes/2025-09-22/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-23/index.html
+++ b/docs/episodes/2025-09-23/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-24/index.html
+++ b/docs/episodes/2025-09-24/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-25/index.html
+++ b/docs/episodes/2025-09-25/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-26/index.html
+++ b/docs/episodes/2025-09-26/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-27/index.html
+++ b/docs/episodes/2025-09-27/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-28/index.html
+++ b/docs/episodes/2025-09-28/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-29/index.html
+++ b/docs/episodes/2025-09-29/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-09-30/index.html
+++ b/docs/episodes/2025-09-30/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-01/index.html
+++ b/docs/episodes/2025-10-01/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-02/index.html
+++ b/docs/episodes/2025-10-02/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-03/index.html
+++ b/docs/episodes/2025-10-03/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-04/index.html
+++ b/docs/episodes/2025-10-04/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-05/index.html
+++ b/docs/episodes/2025-10-05/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-06/index.html
+++ b/docs/episodes/2025-10-06/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-07/index.html
+++ b/docs/episodes/2025-10-07/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-08/index.html
+++ b/docs/episodes/2025-10-08/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-09/index.html
+++ b/docs/episodes/2025-10-09/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -129,16 +126,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-10/index.html
+++ b/docs/episodes/2025-10-10/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -130,16 +127,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-11/index.html
+++ b/docs/episodes/2025-10-11/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -131,16 +128,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/episodes/2025-10-12/index.html
+++ b/docs/episodes/2025-10-12/index.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -132,16 +129,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>Very Little Text</title><link>https://verylittletext.com</link><description>AI-crafted micro-text that blooms into actions.</description><item><title>Subtle Intervals</title><link>https://verylittletext.com/episodes/2025-10-12/</link><guid>https://verylittletext.com/episodes/2025-10-12/</guid><pubDate>Sun, 12 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Kinetic Packets</title><link>https://verylittletext.com/episodes/2025-10-11/</link><guid>https://verylittletext.com/episodes/2025-10-11/</guid><pubDate>Sat, 11 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Granular Intervals</title><link>https://verylittletext.com/episodes/2025-10-10/</link><guid>https://verylittletext.com/episodes/2025-10-10/</guid><pubDate>Fri, 10 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Noisy Revisions</title><link>https://verylittletext.com/episodes/2025-10-09/</link><guid>https://verylittletext.com/episodes/2025-10-09/</guid><pubDate>Thu, 09 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Mutable Rituals</title><link>https://verylittletext.com/episodes/2025-10-08/</link><guid>https://verylittletext.com/episodes/2025-10-08/</guid><pubDate>Wed, 08 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Serial Threads</title><link>https://verylittletext.com/episodes/2025-10-07/</link><guid>https://verylittletext.com/episodes/2025-10-07/</guid><pubDate>Tue, 07 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Elastic Envelopes</title><link>https://verylittletext.com/episodes/2025-10-06/</link><guid>https://verylittletext.com/episodes/2025-10-06/</guid><pubDate>Mon, 06 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Elastic Ledgers</title><link>https://verylittletext.com/episodes/2025-10-05/</link><guid>https://verylittletext.com/episodes/2025-10-05/</guid><pubDate>Sun, 05 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Signed Protocols</title><link>https://verylittletext.com/episodes/2025-10-04/</link><guid>https://verylittletext.com/episodes/2025-10-04/</guid><pubDate>Sat, 04 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Hydrated Loops</title><link>https://verylittletext.com/episodes/2025-10-03/</link><guid>https://verylittletext.com/episodes/2025-10-03/</guid><pubDate>Fri, 03 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Magnetic Intervals</title><link>https://verylittletext.com/episodes/2025-10-02/</link><guid>https://verylittletext.com/episodes/2025-10-02/</guid><pubDate>Thu, 02 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Perpetual Intervals</title><link>https://verylittletext.com/episodes/2025-10-01/</link><guid>https://verylittletext.com/episodes/2025-10-01/</guid><pubDate>Wed, 01 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Speculative Parens</title><link>https://verylittletext.com/episodes/2025-09-30/</link><guid>https://verylittletext.com/episodes/2025-09-30/</guid><pubDate>Tue, 30 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Magnetic Indexes</title><link>https://verylittletext.com/episodes/2025-09-29/</link><guid>https://verylittletext.com/episodes/2025-09-29/</guid><pubDate>Mon, 29 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Perpetual Intervals</title><link>https://verylittletext.com/episodes/2025-09-28/</link><guid>https://verylittletext.com/episodes/2025-09-28/</guid><pubDate>Sun, 28 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Quasi Intervals</title><link>https://verylittletext.com/episodes/2025-09-27/</link><guid>https://verylittletext.com/episodes/2025-09-27/</guid><pubDate>Sat, 27 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Probabilistic Syntax</title><link>https://verylittletext.com/episodes/2025-09-26/</link><guid>https://verylittletext.com/episodes/2025-09-26/</guid><pubDate>Fri, 26 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Noisy Accents</title><link>https://verylittletext.com/episodes/2025-09-25/</link><guid>https://verylittletext.com/episodes/2025-09-25/</guid><pubDate>Thu, 25 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Ghosted Margins</title><link>https://verylittletext.com/episodes/2025-09-24/</link><guid>https://verylittletext.com/episodes/2025-09-24/</guid><pubDate>Wed, 24 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Tuned Intervals</title><link>https://verylittletext.com/episodes/2025-09-23/</link><guid>https://verylittletext.com/episodes/2025-09-23/</guid><pubDate>Tue, 23 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item></channel></rss>

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,8 +31,6 @@
     <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main>
@@ -148,17 +146,6 @@ Evening brings long-tail associations. Paragraphs interleave until causality blu
         activate();
       }
     });
-
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active = b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed', active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
 
   </script>
 </body>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,7 +1,7 @@
 /* Base */
-:root { --col-gap: 1rem; --btn-pad: 0.35rem 0.55rem; --actions-w: 6.5rem; }
-html,body{margin:0;padding:0}
-body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
+:root { --col-gap: 1rem; --btn-pad: 0.35rem 0.55rem; --actions-w: 6.5rem; --teal: #40e0d0; }
+html,body{margin:0;padding:0;box-sizing:border-box}
+body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff;border:0.5rem solid var(--teal);}
 .site-header{padding:1rem 1rem 0.25rem}
 .site-title{margin:0 0 0.25rem;font-weight:800;letter-spacing:-0.01em}
 .site-tag{margin:0;color:#666}
@@ -15,10 +15,11 @@ body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
 /* WALL OF TINY TEXT (flood mode) */
 .micro-lines-container{ padding: 0 1rem 1rem; }
 .mode-flood .micro-lines-container{
-  column-count: 3;
+  column-count: 5;
   column-gap: var(--col-gap);
 }
-@media (max-width: 900px){ .mode-flood .micro-lines-container{ column-count:2; } }
+@media (max-width: 1200px){ .mode-flood .micro-lines-container{ column-count:4; } }
+@media (max-width: 900px){ .mode-flood .micro-lines-container{ column-count:3; } }
 @media (max-width: 600px){ .mode-flood .micro-lines-container{ column-count:1; } }
 
 /* Each microline is a block that avoids breaking across columns */
@@ -27,18 +28,19 @@ body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
   break-inside: avoid;
   padding: .15rem .25rem;
   border-radius: .15rem;
-  transition: background-color .12s ease-in-out;
+  border:1px solid #ddd;
+  transition: background-color .12s ease-in-out, border-color .12s ease-in-out;
 }
-.microline:hover, .microline:focus-within{ background:#fafafa; }
+.microline:hover, .microline:focus-within{ background:#f0f7f7; border-color: var(--teal); }
 
 /* Tiny, dense text; reserve space on the right for actions to prevent CLS */
 .microtext{
   display: block;
-  font-size: .78rem;      /* tiny */
-  line-height: 1.15;      /* dense */
+  font-size: .65rem;      /* tinier */
+  line-height: 1.1;       /* denser */
   letter-spacing: .01em;
   color:#111;
-  margin: 0 calc(var(--actions-w) + .5rem) .12rem 0;  /* reserve action width */
+  margin: 0 calc(var(--actions-w) + .5rem) .1rem 0;  /* reserve action width */
 }
 
 /* Actions: absolutely positioned; fade in (no layout shift) */
@@ -60,14 +62,16 @@ body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
 
 /* Buttons */
 .btn{
-  font-size: .72rem;
-  border: 1px solid #ddd;
+  font-size: .9rem;
+  border: 1px solid #888;
   padding: var(--btn-pad);
   border-radius: .35rem;
-  background: #fff;
+  background: #e0e0e0;
   color:#111;
   text-decoration: none;
+  transition: background-color .12s ease-in-out, color .12s ease-in-out, border-color .12s ease-in-out;
 }
+.btn:hover, .btn:focus{ background: var(--teal); color:#fff; border-color: var(--teal); }
 .btn:focus-visible{ outline: 2px solid #000; outline-offset: 2px; }
 
 /* Flood toggle */
@@ -79,7 +83,8 @@ body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
 }
 
 .mode-flood .flood-toggle{
-  background:#111;
+  background:var(--teal);
+  border-color:var(--teal);
   color:#fff;
 }
 

--- a/episode.html
+++ b/episode.html
@@ -30,9 +30,6 @@
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main class="episode">
@@ -70,16 +67,6 @@
         activate();
       }
     });
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active=b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed',active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /* Base */
-:root { --col-gap: 1rem; --btn-pad: 0.35rem 0.55rem; --actions-w: 6.5rem; }
-html,body{margin:0;padding:0}
-body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
+:root { --col-gap: 1rem; --btn-pad: 0.35rem 0.55rem; --actions-w: 6.5rem; --teal: #40e0d0; }
+html,body{margin:0;padding:0;box-sizing:border-box}
+body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff;border:0.5rem solid var(--teal);}
 .site-header{padding:1rem 1rem 0.25rem}
 .site-title{margin:0 0 0.25rem;font-weight:800;letter-spacing:-0.01em}
 .site-tag{margin:0;color:#666}
@@ -15,10 +15,11 @@ body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
 /* WALL OF TINY TEXT (flood mode) */
 .micro-lines-container{ padding: 0 1rem 1rem; }
 .mode-flood .micro-lines-container{
-  column-count: 3;
+  column-count: 5;
   column-gap: var(--col-gap);
 }
-@media (max-width: 900px){ .mode-flood .micro-lines-container{ column-count:2; } }
+@media (max-width: 1200px){ .mode-flood .micro-lines-container{ column-count:4; } }
+@media (max-width: 900px){ .mode-flood .micro-lines-container{ column-count:3; } }
 @media (max-width: 600px){ .mode-flood .micro-lines-container{ column-count:1; } }
 
 /* Each microline is a block that avoids breaking across columns */
@@ -27,18 +28,19 @@ body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
   break-inside: avoid;
   padding: .15rem .25rem;
   border-radius: .15rem;
-  transition: background-color .12s ease-in-out;
+  border:1px solid #ddd;
+  transition: background-color .12s ease-in-out, border-color .12s ease-in-out;
 }
-.microline:hover, .microline:focus-within{ background:#fafafa; }
+.microline:hover, .microline:focus-within{ background:#f0f7f7; border-color: var(--teal); }
 
 /* Tiny, dense text; reserve space on the right for actions to prevent CLS */
 .microtext{
   display: block;
-  font-size: .78rem;      /* tiny */
-  line-height: 1.15;      /* dense */
+  font-size: .65rem;      /* tinier */
+  line-height: 1.1;       /* denser */
   letter-spacing: .01em;
   color:#111;
-  margin: 0 calc(var(--actions-w) + .5rem) .12rem 0;  /* reserve action width */
+  margin: 0 calc(var(--actions-w) + .5rem) .1rem 0;  /* reserve action width */
 }
 
 /* Actions: absolutely positioned; fade in (no layout shift) */
@@ -60,14 +62,16 @@ body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
 
 /* Buttons */
 .btn{
-  font-size: .72rem;
-  border: 1px solid #ddd;
+  font-size: .9rem;
+  border: 1px solid #888;
   padding: var(--btn-pad);
   border-radius: .35rem;
-  background: #fff;
+  background: #e0e0e0;
   color:#111;
   text-decoration: none;
+  transition: background-color .12s ease-in-out, color .12s ease-in-out, border-color .12s ease-in-out;
 }
+.btn:hover, .btn:focus{ background: var(--teal); color:#fff; border-color: var(--teal); }
 .btn:focus-visible{ outline: 2px solid #000; outline-offset: 2px; }
 
 /* Flood toggle */
@@ -79,7 +83,8 @@ body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff}
 }
 
 .mode-flood .flood-toggle{
-  background:#111;
+  background:var(--teal);
+  border-color:var(--teal);
   color:#fff;
 }
 

--- a/template.html
+++ b/template.html
@@ -31,8 +31,6 @@
     <p class="site-tag">{{TAGLINE}}</p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
-    <button id="flood-toggle" class="btn flood-toggle" type="button">Flood</button>
-
   </header>
 
   <main>
@@ -86,17 +84,6 @@
         activate();
       }
     });
-
-    const ft=document.getElementById('flood-toggle');
-    const b=document.body;
-    ft.addEventListener('click',()=>{
-      const active = b.classList.toggle('mode-flood');
-      ft.setAttribute('aria-pressed', active);
-    });
-    ft.addEventListener('mouseenter',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('mouseleave',()=>b.classList.remove('mode-flood'));
-    ft.addEventListener('focus',()=>b.classList.add('mode-flood'));
-    ft.addEventListener('blur',()=>b.classList.remove('mode-flood'));
 
   </script>
 </body>


### PR DESCRIPTION
## Summary
- introduce a grey/turquoise theme with a visible page frame
- compress flood mode to show more micro-lines per screen
- remove duplicate flood toggle button and redundant JavaScript

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a099b5eb888329894ab66ed78acde9