### PR TITLE
Add animated checkered background and GitHub header link

### DIFF
--- a/docs/episodes/2025-08-14/index.html
+++ b/docs/episodes/2025-08-14/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-15/index.html
+++ b/docs/episodes/2025-08-15/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-16/index.html
+++ b/docs/episodes/2025-08-16/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-17/index.html
+++ b/docs/episodes/2025-08-17/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-18/index.html
+++ b/docs/episodes/2025-08-18/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-19/index.html
+++ b/docs/episodes/2025-08-19/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-20/index.html
+++ b/docs/episodes/2025-08-20/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-21/index.html
+++ b/docs/episodes/2025-08-21/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-22/index.html
+++ b/docs/episodes/2025-08-22/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-23/index.html
+++ b/docs/episodes/2025-08-23/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-24/index.html
+++ b/docs/episodes/2025-08-24/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-25/index.html
+++ b/docs/episodes/2025-08-25/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-26/index.html
+++ b/docs/episodes/2025-08-26/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-27/index.html
+++ b/docs/episodes/2025-08-27/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-28/index.html
+++ b/docs/episodes/2025-08-28/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-29/index.html
+++ b/docs/episodes/2025-08-29/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-30/index.html
+++ b/docs/episodes/2025-08-30/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-08-31/index.html
+++ b/docs/episodes/2025-08-31/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-01/index.html
+++ b/docs/episodes/2025-09-01/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-02/index.html
+++ b/docs/episodes/2025-09-02/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-03/index.html
+++ b/docs/episodes/2025-09-03/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-04/index.html
+++ b/docs/episodes/2025-09-04/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-05/index.html
+++ b/docs/episodes/2025-09-05/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-06/index.html
+++ b/docs/episodes/2025-09-06/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-07/index.html
+++ b/docs/episodes/2025-09-07/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-08/index.html
+++ b/docs/episodes/2025-09-08/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-09/index.html
+++ b/docs/episodes/2025-09-09/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-10/index.html
+++ b/docs/episodes/2025-09-10/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-11/index.html
+++ b/docs/episodes/2025-09-11/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-12/index.html
+++ b/docs/episodes/2025-09-12/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-13/index.html
+++ b/docs/episodes/2025-09-13/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-14/index.html
+++ b/docs/episodes/2025-09-14/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-15/index.html
+++ b/docs/episodes/2025-09-15/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-16/index.html
+++ b/docs/episodes/2025-09-16/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-17/index.html
+++ b/docs/episodes/2025-09-17/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-18/index.html
+++ b/docs/episodes/2025-09-18/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-19/index.html
+++ b/docs/episodes/2025-09-19/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-20/index.html
+++ b/docs/episodes/2025-09-20/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-21/index.html
+++ b/docs/episodes/2025-09-21/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-22/index.html
+++ b/docs/episodes/2025-09-22/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-23/index.html
+++ b/docs/episodes/2025-09-23/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-24/index.html
+++ b/docs/episodes/2025-09-24/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-25/index.html
+++ b/docs/episodes/2025-09-25/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-26/index.html
+++ b/docs/episodes/2025-09-26/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-27/index.html
+++ b/docs/episodes/2025-09-27/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-28/index.html
+++ b/docs/episodes/2025-09-28/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-29/index.html
+++ b/docs/episodes/2025-09-29/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-09-30/index.html
+++ b/docs/episodes/2025-09-30/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-01/index.html
+++ b/docs/episodes/2025-10-01/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-02/index.html
+++ b/docs/episodes/2025-10-02/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-03/index.html
+++ b/docs/episodes/2025-10-03/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-04/index.html
+++ b/docs/episodes/2025-10-04/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-05/index.html
+++ b/docs/episodes/2025-10-05/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-06/index.html
+++ b/docs/episodes/2025-10-06/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-07/index.html
+++ b/docs/episodes/2025-10-07/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-08/index.html
+++ b/docs/episodes/2025-10-08/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-09/index.html
+++ b/docs/episodes/2025-10-09/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-10/index.html
+++ b/docs/episodes/2025-10-10/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-11/index.html
+++ b/docs/episodes/2025-10-11/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/episodes/2025-10-12/index.html
+++ b/docs/episodes/2025-10-12/index.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>Very Little Text</title><link>https://verylittletext.com</link><description>AI-crafted micro-text that blooms into actions.</description><item><title>Subtle Intervals</title><link>https://verylittletext.com/episodes/2025-10-12/</link><guid>https://verylittletext.com/episodes/2025-10-12/</guid><pubDate>Sun, 12 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Kinetic Packets</title><link>https://verylittletext.com/episodes/2025-10-11/</link><guid>https://verylittletext.com/episodes/2025-10-11/</guid><pubDate>Sat, 11 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Granular Intervals</title><link>https://verylittletext.com/episodes/2025-10-10/</link><guid>https://verylittletext.com/episodes/2025-10-10/</guid><pubDate>Fri, 10 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Noisy Revisions</title><link>https://verylittletext.com/episodes/2025-10-09/</link><guid>https://verylittletext.com/episodes/2025-10-09/</guid><pubDate>Thu, 09 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Mutable Rituals</title><link>https://verylittletext.com/episodes/2025-10-08/</link><guid>https://verylittletext.com/episodes/2025-10-08/</guid><pubDate>Wed, 08 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Serial Threads</title><link>https://verylittletext.com/episodes/2025-10-07/</link><guid>https://verylittletext.com/episodes/2025-10-07/</guid><pubDate>Tue, 07 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Elastic Envelopes</title><link>https://verylittletext.com/episodes/2025-10-06/</link><guid>https://verylittletext.com/episodes/2025-10-06/</guid><pubDate>Mon, 06 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Elastic Ledgers</title><link>https://verylittletext.com/episodes/2025-10-05/</link><guid>https://verylittletext.com/episodes/2025-10-05/</guid><pubDate>Sun, 05 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Signed Protocols</title><link>https://verylittletext.com/episodes/2025-10-04/</link><guid>https://verylittletext.com/episodes/2025-10-04/</guid><pubDate>Sat, 04 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Hydrated Loops</title><link>https://verylittletext.com/episodes/2025-10-03/</link><guid>https://verylittletext.com/episodes/2025-10-03/</guid><pubDate>Fri, 03 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Magnetic Intervals</title><link>https://verylittletext.com/episodes/2025-10-02/</link><guid>https://verylittletext.com/episodes/2025-10-02/</guid><pubDate>Thu, 02 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Perpetual Intervals</title><link>https://verylittletext.com/episodes/2025-10-01/</link><guid>https://verylittletext.com/episodes/2025-10-01/</guid><pubDate>Wed, 01 Oct 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Speculative Parens</title><link>https://verylittletext.com/episodes/2025-09-30/</link><guid>https://verylittletext.com/episodes/2025-09-30/</guid><pubDate>Tue, 30 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Magnetic Indexes</title><link>https://verylittletext.com/episodes/2025-09-29/</link><guid>https://verylittletext.com/episodes/2025-09-29/</guid><pubDate>Mon, 29 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Perpetual Intervals</title><link>https://verylittletext.com/episodes/2025-09-28/</link><guid>https://verylittletext.com/episodes/2025-09-28/</guid><pubDate>Sun, 28 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Quasi Intervals</title><link>https://verylittletext.com/episodes/2025-09-27/</link><guid>https://verylittletext.com/episodes/2025-09-27/</guid><pubDate>Sat, 27 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Probabilistic Syntax</title><link>https://verylittletext.com/episodes/2025-09-26/</link><guid>https://verylittletext.com/episodes/2025-09-26/</guid><pubDate>Fri, 26 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Noisy Accents</title><link>https://verylittletext.com/episodes/2025-09-25/</link><guid>https://verylittletext.com/episodes/2025-09-25/</guid><pubDate>Thu, 25 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Ghosted Margins</title><link>https://verylittletext.com/episodes/2025-09-24/</link><guid>https://verylittletext.com/episodes/2025-09-24/</guid><pubDate>Wed, 24 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item>
+<item><title>Tuned Intervals</title><link>https://verylittletext.com/episodes/2025-09-23/</link><guid>https://verylittletext.com/episodes/2025-09-23/</guid><pubDate>Tue, 23 Sep 2025 00:00:00 GMT</pubDate><description>The page wakes in increments. Words arrive in orderly trickles, behaving like a system that scales under load. Nothing is urgent; pressure distributes, and the text equilibrates.
+
+By midday, motifs recur with intention. Lines resurface in altered forms, a controlled recurrence that hints at invariants beneath the prose. Pauses act as flow control, keeping meaning lossless.
+
+Evening brings long-tail associations. Paragraphs interleave until causality blurs, yet the signal persists. No terminal punctuation—only an interface where the next packet will land.</description></item></channel></rss>

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,7 @@
   <header class="site-header">
     <h1 class="site-title">Very Little Text</h1>
     <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,10 +1,28 @@
 /* Base */
 :root { --col-gap: 1rem; --btn-pad: 0.35rem 0.55rem; --actions-w: 6.5rem; --teal: #40e0d0; }
 html,body{margin:0;padding:0;box-sizing:border-box}
-body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff;border:0.5rem solid var(--teal);}
-.site-header{padding:1rem 1rem 0.25rem}
-.site-title{margin:0 0 0.25rem;font-weight:800;letter-spacing:-0.01em}
-.site-tag{margin:0;color:#666}
+body{
+  font:16px/1.45 "Times New Roman",Times,serif;
+  color:#111;
+  border:0.5rem solid var(--teal);
+  background:conic-gradient(#3498db 0 25%, #f0f0f0 0 50%, #3498db 0 75%, #f0f0f0 0);
+  background-size:2rem 2rem;
+  animation:fold 4s linear infinite;
+}
+.site-header{padding:1rem 1rem 0.5rem;text-align:center}
+.site-title{margin:0;font-weight:800;letter-spacing:-0.01em;font-size:2rem}
+.site-tag{margin:0;color:#666;font-style:italic}
+.site-github{margin-top:.5rem}
+.site-github a{color:var(--teal);text-decoration:none}
+.site-github a:hover{text-decoration:underline}
+
+@keyframes fold{
+  0%{background-position:0 0}
+  25%{background-position:2rem 0}
+  50%{background-position:2rem 2rem}
+  75%{background-position:0 2rem}
+  100%{background-position:0 0}
+}
 
 /* Episode summary */
 .episode{padding:0 1rem 0.5rem;border-bottom:1px solid #eee}

--- a/episode.html
+++ b/episode.html
@@ -28,6 +28,8 @@
 <body>
   <header class="site-header">
     <h1 class="site-title"><a href="/">Very Little Text</a></h1>
+    <p class="site-tag">{{TAGLINE}}</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>

--- a/generate.mjs
+++ b/generate.mjs
@@ -107,6 +107,7 @@ async function build(){
     const epHtml = episodeTemplate
       .replace(/{{STORY_TITLE}}/g, escapeHtml(story.title))
       .replace(/{{SITE_NAME}}/g, escapeHtml(site.name))
+      .replace(/{{TAGLINE}}/g, escapeHtml(site.tagline))
       .replace(/{{DATE_ISO}}/g, story.date)
       .replace(/{{STORY_BODY}}/g, escapeHtml(story.body))
       .replace(/{{MICRO_LINES}}/g, microLinesEp)

--- a/index.html
+++ b/index.html
@@ -19,10 +19,15 @@
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Very Little Text","url":"https://verylittletext.com","description":"AI-crafted micro-text that blooms into actions."}</script>
 </head>
 <body>
-  <article>
-    <h1>Flood of Words</h1>
-    <time datetime="2025-08-14">2025-08-14</time>
-    <p id="m1">The page inhales. Tiny sentences arrive like rain across glass. Nothing shouts; everything accumulates until it feels like weather.</p>
+  <header class="site-header">
+    <h1 class="site-title">Very Little Text</h1>
+    <p class="site-tag">AI-crafted micro-text that blooms into actions.</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
+  </header>
+  <article class="episode">
+    <h2 class="episode-title">Flood of Words</h2>
+    <time datetime="2025-08-14" class="episode-date">2025-08-14</time>
+    <p id="m1" class="episode-body">The page inhales. Tiny sentences arrive like rain across glass. Nothing shouts; everything accumulates until it feels like weather.</p>
   </article>
   <section class="micro-list">
     <div class="microline">Streetlights rehearse for sunrise.<div class="actions"><a class="btn" href="episodes/2025-08-14/#m1">Open</a> <a class="btn" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fverylittletext.com%2Fepisodes%2F2025-08-14%2F">Share</a> <a class="btn" href="episodes/2025-08-14/#m1#like">Like</a></div></div>

--- a/style.css
+++ b/style.css
@@ -1,10 +1,28 @@
 /* Base */
 :root { --col-gap: 1rem; --btn-pad: 0.35rem 0.55rem; --actions-w: 6.5rem; --teal: #40e0d0; }
 html,body{margin:0;padding:0;box-sizing:border-box}
-body{font:16px/1.45 "Times New Roman",Times,serif;color:#111;background:#fff;border:0.5rem solid var(--teal);}
-.site-header{padding:1rem 1rem 0.25rem}
-.site-title{margin:0 0 0.25rem;font-weight:800;letter-spacing:-0.01em}
-.site-tag{margin:0;color:#666}
+body{
+  font:16px/1.45 "Times New Roman",Times,serif;
+  color:#111;
+  border:0.5rem solid var(--teal);
+  background:conic-gradient(#3498db 0 25%, #f0f0f0 0 50%, #3498db 0 75%, #f0f0f0 0);
+  background-size:2rem 2rem;
+  animation:fold 4s linear infinite;
+}
+.site-header{padding:1rem 1rem 0.5rem;text-align:center}
+.site-title{margin:0;font-weight:800;letter-spacing:-0.01em;font-size:2rem}
+.site-tag{margin:0;color:#666;font-style:italic}
+.site-github{margin-top:.5rem}
+.site-github a{color:var(--teal);text-decoration:none}
+.site-github a:hover{text-decoration:underline}
+
+@keyframes fold{
+  0%{background-position:0 0}
+  25%{background-position:2rem 0}
+  50%{background-position:2rem 2rem}
+  75%{background-position:0 2rem}
+  100%{background-position:0 0}
+}
 
 /* Episode summary */
 .episode{padding:0 1rem 0.5rem;border-bottom:1px solid #eee}

--- a/template.html
+++ b/template.html
@@ -29,6 +29,7 @@
   <header class="site-header">
     <h1 class="site-title">Very Little Text</h1>
     <p class="site-tag">{{TAGLINE}}</p>
+    <p class="site-github"><a href="https://github.com/VeryLittleText/VeryLittleText" target="_blank" rel="noopener">Source on GitHub</a></p>
     <button id="flood-toggle" class="btn flood-toggle" type="button" aria-pressed="false">Flood</button>
 
   </header>


### PR DESCRIPTION
## Summary
- animate a conic-gradient background to create an endlessly folding blue checkerboard
- surface project details in a centered header with tagline and GitHub source link
- ensure episode pages reuse the tagline and GitHub link

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d431c63483298876de9c1799589b